### PR TITLE
Create Limited Data Transmitter.cfg

### DIFF
--- a/GameData/000_FilterExtensions/Configs/Category_Filter_by_Module/Connected Living Space.cfg
+++ b/GameData/000_FilterExtensions/Configs/Category_Filter_by_Module/Connected Living Space.cfg
@@ -1,0 +1,6 @@
+SUBCATEGORY
+{
+    category = Filter by Module
+    title = Connected Living Space
+    icon = R&D_node_icon_evatech
+}

--- a/GameData/000_FilterExtensions/Configs/Category_Filter_by_Module/Limited Data Transmitter.cfg
+++ b/GameData/000_FilterExtensions/Configs/Category_Filter_by_Module/Limited Data Transmitter.cfg
@@ -1,0 +1,7 @@
+SUBCATEGORY
+{
+    category = Filter by Module
+    title = Limited Data Transmitter
+    oldTitle = Limited Data Transmitter
+    icon = R&D_node_icon_advunmanned
+}


### PR DESCRIPTION
I like the look of R&D_node_icon_advunmanned vs. DataTransmitter because it's darker, so it fits better with the other tech-tree icons that are used as module symbols (vs. the lighter part-category icons that DataTransmitter and the other part icons are meant to fit with).  On the other hand, data transmitters can be put on things besides satellites, so the satellite image may be a bit misleading.  What do you think?